### PR TITLE
Fixes for D4S2 API changes that now return _id fields for relationships

### DIFF
--- a/app/serializers/delivery.js
+++ b/app/serializers/delivery.js
@@ -1,11 +1,20 @@
 import ApplicationSerializer from './application';
+import { singularize } from 'ember-inflector';
 
 export default ApplicationSerializer.extend({
   // Related fields from the delivery (e.g. project) are specified with an `_id` suffix in the
   // incoming JSON payload. But Ember treats these as related objects, so it's more natural for
   // the ember model to use a field like `project` rather than `project_id`
-  keyForRelationship(key) {
+  keyForRelationship(key, relationship) {
     const localKey = this._super(key);
-    return `${localKey}_id`;
+    if(relationship == 'hasMany') {
+      // For hasMany relationships, make the key singular, since we'll be pluralizing id
+      return `${singularize(localKey)}_ids`;
+    } else if(relationship == 'belongsTo') {
+      // for belongsTo relationships, just append _id
+      return `${localKey}_id`;
+    } else {
+      return localKey;
+    }
   }
 });

--- a/app/serializers/delivery.js
+++ b/app/serializers/delivery.js
@@ -1,0 +1,11 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  // Related fields from the delivery (e.g. project) are specified with an `_id` suffix in the
+  // incoming JSON payload. But Ember treats these as related objects, so it's more natural for
+  // the ember model to use a field like `project` rather than `project_id`
+  keyForRelationship(key) {
+    const localKey = this._super(key);
+    return `${localKey}_id`;
+  }
+});

--- a/tests/unit/serializers/delivery-test.js
+++ b/tests/unit/serializers/delivery-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('delivery', 'Unit | Serializer | delivery', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:delivery']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/delivery-test.js
+++ b/tests/unit/serializers/delivery-test.js
@@ -1,15 +1,11 @@
-import { moduleForModel, test } from 'ember-qunit';
+import { moduleFor, test } from 'ember-qunit';
 
-moduleForModel('delivery', 'Unit | Serializer | delivery', {
-  // Specify the other units that are required for this test.
-  needs: ['serializer:delivery']
-});
+moduleFor('serializer:delivery', 'Unit | Serializer | delivery');
 
-// Replace this with your real tests.
-test('it serializes records', function(assert) {
-  let record = this.subject();
-
-  let serializedRecord = record.serialize();
-
-  assert.ok(serializedRecord);
+test('it converts relationship keys to underscore and appends _id', function (assert) {
+  let serializer = this.subject();
+  const relationshipKey = serializer.keyForRelationship('someRelationship');
+  assert.equal(relationshipKey, 'some_relationship_id');
+  const attributeKey = serializer.keyForAttribute('someAttribute');
+  assert.equal(attributeKey, 'some_attribute');
 });

--- a/tests/unit/serializers/delivery-test.js
+++ b/tests/unit/serializers/delivery-test.js
@@ -2,10 +2,20 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('serializer:delivery', 'Unit | Serializer | delivery');
 
-test('it converts relationship keys to underscore and appends _id', function (assert) {
+test('it converts belongsTo relationships to underscore and appends _id', function (assert) {
   let serializer = this.subject();
-  const relationshipKey = serializer.keyForRelationship('someRelationship');
-  assert.equal(relationshipKey, 'some_relationship_id');
-  const attributeKey = serializer.keyForAttribute('someAttribute');
-  assert.equal(attributeKey, 'some_attribute');
+  const belongsToKey = serializer.keyForRelationship('fromUser', 'belongsTo');
+  assert.equal(belongsToKey, 'from_user_id');
+});
+
+test('it converts hasMany relationships to underscore, singularizes, and appends _ids', function (assert) {
+  let serializer = this.subject();
+  const hasMany = serializer.keyForRelationship('shareUsers', 'hasMany');
+  assert.equal(hasMany, 'share_user_ids');
+});
+
+test('it does not append anything to attributes', function (assert) {
+  let serializer = this.subject();
+  const attributeKey = serializer.keyForAttribute('userMessage');
+  assert.equal(attributeKey, 'user_message');
 });


### PR DESCRIPTION
https://github.com/Duke-GCB/D4S2/pull/105 updated the Delivery payload to `_id` or `_ids` to related fields. This change updates the serializer for the `delivery` model to resolve these fields to their existing relationship names (e.g. `from_user_id` <-> `fromUser`)