### PR TITLE
Fixes broken resend functionality

### DIFF
--- a/app/adapters/duke-ds-user.js
+++ b/app/adapters/duke-ds-user.js
@@ -1,0 +1,15 @@
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+  urlForQueryRecord(query, modelName) {
+    /*
+    From https://emberjs.com/api/ember-data/2.16.0/classes/DS.Store/methods/queryRecord?anchor=queryRecord
+    > queryRecord makes a request for one record, where the id is not known beforehand
+    > (if the id is known, use findRecord instead).
+    Initially tried findRecord, passing 'current-user' as the ID. But this causes Ember Data to raise warnings
+    about the id 'current-user' not matching the record's id returned in the payload.
+    So instead, they recommend using queryRecord, and we can simply override urlForQueryRecord
+    */
+    return this.buildURL(modelName, 'current-duke-ds-user');
+  }
+});

--- a/app/controllers/deliveries/show/can-resend-controller.js
+++ b/app/controllers/deliveries/show/can-resend-controller.js
@@ -1,29 +1,29 @@
-// Base controller that provides a canResend computed property based on the model and the current user
+// Base controller that provides a canResend computed property based on the model and the current DukeDS User
 // Assumes model is a duke-ds-project-transfer. Uses service to lookup current user via an observer
 // so the value of canResend may change when this service resolves.
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
   session: Ember.inject.service('session'),
-  user: Ember.inject.service('user'),
-  currentUser: null,
-  canResend: Ember.computed('model.canResend', 'model.fromUser.id', 'currentUser.dukeDsUser.id', function () {
+  dukeDsUser: Ember.inject.service('duke-ds-user'),
+  currentDukeDsUser: null,
+  canResend: Ember.computed('model.canResend', 'model.fromUser.id', 'currentDukeDsUser.id', function () {
     const modelCanResend = this.get('model.canResend');
     const fromUserId = this.get('model.fromUser.id');
-    const currentUserId = this.get('currentUser.dukeDsUser.id');
-    if (!currentUserId) {
+    const currentDukeDsUserId = this.get('currentDukeDsUser.id');
+    if (!currentDukeDsUserId) {
       return false;
     }
-    return modelCanResend && fromUserId == currentUserId;
+    return modelCanResend && fromUserId == currentDukeDsUserId;
   }),
   authenticatedDidChange: Ember.on('init',
     Ember.observer('session.isAuthenticated', function() {
       if (this.get('session.isAuthenticated')) {
-        this.get('user').currentUser().then(currentUser => {
-          this.set('currentUser', currentUser);
+        this.get('dukeDsUser').currentDukeDsUser().then(currentDukeDsUser => {
+          this.set('currentDukeDsUser', currentDukeDsUser);
         });
       } else {
-        this.set('currentUser', null);
+        this.set('currentDukeDsUser', null);
       }
     })
   )

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -4,6 +4,5 @@ export default DS.Model.extend({
   username: DS.attr('string'),
   first_name: DS.attr('string'),
   last_name: DS.attr('string'),
-  email: DS.attr('string'),
-  dukeDsUser: DS.belongsTo('DukeDsUser')
+  email: DS.attr('string')
 });

--- a/app/services/duke-ds-user.js
+++ b/app/services/duke-ds-user.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Service.extend({
   store: Ember.inject.service(),
-  currentUser() {
+  currentDukeDsUser() {
     // Use queryRecord since Ember complains that 'current-duke-ds-user'
     // doesn't match the returned ID.
     return this.get('store').queryRecord('duke-ds-user', {});

--- a/app/services/duke-ds-user.js
+++ b/app/services/duke-ds-user.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export default Ember.Service.extend({
+  store: Ember.inject.service(),
+  currentUser() {
+    // Use queryRecord since Ember complains that 'current-duke-ds-user'
+    // doesn't match the returned ID.
+    return this.get('store').queryRecord('duke-ds-user', {});
+  }
+});

--- a/tests/unit/adapters/duke-ds-user-test.js
+++ b/tests/unit/adapters/duke-ds-user-test.js
@@ -1,0 +1,17 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:duke-ds-user', 'Unit | Adapter | duke ds user', {
+  // Specify the other units that are required for this test.
+  needs: ['service:session']
+});
+
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});
+
+test('it returns current-duke-ds-user url for queryRecord', function(assert) {
+  let adapter = this.subject();
+  let url = adapter.urlForQueryRecord({}, 'duke-ds-user');
+  assert.equal(url, 'http://testhost/duke-ds-users/current-duke-ds-user/')
+});

--- a/tests/unit/controllers/deliveries/show/can-resend-controller-test.js
+++ b/tests/unit/controllers/deliveries/show/can-resend-controller-test.js
@@ -3,53 +3,53 @@ import Ember from 'ember';
 
 moduleFor('controller:deliveries/show/can-resend-controller', 'Unit | Controller | deliveries/show/can resend controller', {
   // Specify the other units that are required for this test.
-  needs: ['service:session', 'service:user', 'model:user']
+  needs: ['service:session', 'service:duke-ds-user', 'model:duke-ds-user']
 });
 
 
-test('it fetches currentUser when session.isAuthenticated changes', function(assert) {
+test('it fetches currentDukeDsUser when session.isAuthenticated changes', function(assert) {
   assert.expect(4);
   const mockSessionService = Ember.Object.create({
     isAuthenticated: false
   });
-  const mockUser = Ember.Object.create({ id: 6, username: 'samus'});
-  const mockUserService = Ember.Object.create({
-    currentUser() {
+  const mockDukeDsUser = Ember.Object.create({ id: 6, username: 'samus'});
+  const mockDukeDSUserService = Ember.Object.create({
+    currentDukeDsUser() {
       assert.ok(true); // Ensure this is called
-      return Ember.RSVP.resolve(mockUser);
+      return Ember.RSVP.resolve(mockDukeDsUser);
     }
   });
   let controller = this.subject({
     session: mockSessionService,
-    user: mockUserService
+    dukeDsUser: mockDukeDSUserService
   });
 
   // In one run loop, set isAuthenticated = true
   Ember.run(() => {
-    assert.equal(controller.get('currentUser'), null); // currentUser should be null when session is not authenticated
+    assert.equal(controller.get('currentDukeDsUser'), null); // currentDukeDsUser should be null when session is not authenticated
     mockSessionService.set('isAuthenticated', true);
   });
 
   // In the next, assert that the current User updated. Then clear authentication
   Ember.run(() => {
-    assert.equal(controller.get('currentUser'), mockUser); // currentUser should be fetched when session is authenticated
+    assert.equal(controller.get('currentDukeDsUser'), mockDukeDsUser); // currentDukeDsUser should be fetched when session is authenticated
     mockSessionService.set('isAuthenticated', false);
   });
 
-  // Finally, assert that currentUser is null again
+  // Finally, assert that currentDukeDsUser is null again
   Ember.run(() => {
-    assert.equal(controller.get('currentUser'), null); // currentUser should be null when session is not authenticated
+    assert.equal(controller.get('currentDukeDsUser'), null); // currentDukeDsUser should be null when session is not authenticated
   });
 });
 
-test('canResend is false when no currentUser', function(assert) {
+test('canResend is false when no currentDukeDsUser', function(assert) {
   let controller = this.subject({
-    currentUser: null
+    currentDukeDsUser: null
   });
   assert.equal(controller.get('canResend'), false);
 });
 
-test('canResend is true when model.canResend and currentUser is fromUser', function(assert) {
+test('canResend is true when model.canResend and currentDukeDsUser is fromUser', function(assert) {
   let controller = this.subject({
     model: Ember.Object.create({
       canResend: true,
@@ -59,53 +59,37 @@ test('canResend is true when model.canResend and currentUser is fromUser', funct
     }),
   });
   Ember.run(() => {
-    controller.set('currentUser', Ember.Object.create({
-      dukeDsUser: Ember.Object.create({
-        id: '123'
-      })
-    }));
+    controller.set('currentDukeDsUser', Ember.Object.create({id: '123'}));
   });
   Ember.run(() => {
     assert.equal(controller.get('canResend'), true);
   });
 });
 
-test('canResend is false when not model.canResend and currentUser is fromUser', function(assert) {
+test('canResend is false when not model.canResend and currentDukeDsUser is fromUser', function(assert) {
   let controller = this.subject({
     model: Ember.Object.create({
       canResend: false,
-      fromUser: Ember.Object.create({
-        id: '123'
-      })
+      fromUser: Ember.Object.create({id: '123'})
     }),
   });
   Ember.run(() => {
-    controller.set('currentUser', Ember.Object.create({
-      dukeDsUser: Ember.Object.create({
-        id: '123'
-      })
-    }));
+    controller.set('currentDukeDsUser', Ember.Object.create({id: '123'}));
   });
   Ember.run(() => {
     assert.equal(controller.get('canResend'), false);
   });
 });
 
-test('canResend is false when model.canResend and currentUser is not fromUser', function(assert) {
+test('canResend is false when model.canResend and currentDukeDsUser is not fromUser', function(assert) {
   let controller = this.subject({
     model: Ember.Object.create({
       canResend: false,
-      fromUser: Ember.Object.create({
-        id: '123'
-      })
+      fromUser: Ember.Object.create({id: '123'})
     }),
   });
   Ember.run(() => {
-    controller.set('currentUser', Ember.Object.create({
-      dukeDsUser: Ember.Object.create({
-        id: '124'
-      })
-    }));
+    controller.set('currentDukeDsUser', Ember.Object.create({id: '124'}));
   });
   Ember.run(() => {
     assert.equal(controller.get('canResend'), false);

--- a/tests/unit/controllers/deliveries/show/index-test.js
+++ b/tests/unit/controllers/deliveries/show/index-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:deliveries/show/index', 'Unit | Controller | deliveries/show/index', {
   // Specify the other units that are required for this test.
-  needs: ['service:session', 'service:user', 'model:user']
+  needs: ['service:session', 'service:duke-ds-user', 'model:duke-ds-user']
 });
 
 test('it is ok', function(assert) {

--- a/tests/unit/controllers/deliveries/show/resend-test.js
+++ b/tests/unit/controllers/deliveries/show/resend-test.js
@@ -3,10 +3,10 @@ import Ember from 'ember';
 
 moduleFor('controller:deliveries/show/resend', 'Unit | Controller | deliveries/show/resend', {
   // Specify the other units that are required for this test.
-  needs: ['service:session', 'service:user', 'model:user']
+  needs: ['service:session', 'service:duke-ds-user', 'model:duke-ds-user']
 });
 
-test('it resending delivery transitions to deliveries.show', function(assert) {
+test('it transitions to deliveries.show after resend', function(assert) {
   let done = assert.async();
   const delivery = Ember.Object.create({});
   const transfer = Ember.Object.create({

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -1,5 +1,4 @@
 import { moduleForModel, test } from 'ember-qunit';
-import { testRelationships } from '../../helpers/test-relationships';
 
 moduleForModel('user', 'Unit | Model | user', {
   // Specify the other units that are required for this test.
@@ -11,9 +10,3 @@ test('it exists', function(assert) {
   // let store = this.store();
   assert.ok(!!model);
 });
-
-const relationships = [
-  {key: 'dukeDsUser', kind: 'belongsTo', type: 'duke-ds-user'},
-];
-
-testRelationships('user', relationships);

--- a/tests/unit/services/duke-ds-user-test.js
+++ b/tests/unit/services/duke-ds-user-test.js
@@ -1,0 +1,30 @@
+import { moduleFor, test } from 'ember-qunit';
+import Ember from "ember";
+
+const DukeDSUserStoreStub = Ember.Object.extend({
+  queryRecord(modelName) {
+    return Ember.RSVP.resolve({
+      modelName: modelName,
+      username: 'dds111'
+    });
+  }
+});
+
+
+moduleFor('service:duke-ds-user', 'Unit | Service | duke ds user', {
+  needs: ['model:duke-ds-user'],
+  beforeEach() {
+    this.register('service:store', DukeDSUserStoreStub);
+    this.inject.service('store', {as: 'store'});
+  }
+});
+
+test('it queries duke-ds-users/current-duke-ds-user from the store', function(assert) {
+  assert.expect(3);
+  let service = this.subject();
+  assert.ok(service);
+  service.currentUser().then(function(user) {
+    assert.equal(user.modelName, 'duke-ds-user');
+    assert.equal(user.username, 'dds111');
+  });
+});

--- a/tests/unit/services/duke-ds-user-test.js
+++ b/tests/unit/services/duke-ds-user-test.js
@@ -23,7 +23,7 @@ test('it queries duke-ds-users/current-duke-ds-user from the store', function(as
   assert.expect(3);
   let service = this.subject();
   assert.ok(service);
-  service.currentUser().then(function(user) {
+  service.currentDukeDsUser().then(function(user) {
     assert.equal(user.modelName, 'duke-ds-user');
     assert.equal(user.username, 'dds111');
   });


### PR DESCRIPTION
As described in #12, removing the current DukeDSUser details from the D4S2 current user API breaks this application's ability to determine what deliveries a user can resend.

These changes update the can-resend-controller to use the current Duke DS user as implemented in  https://github.com/Duke-GCB/D4S2/pull/160 to restore that functionality.

Fixes #12 