### PR TITLE
Displays delivery emails before send or resend

### DIFF
--- a/app/adapters/delivery.js
+++ b/app/adapters/delivery.js
@@ -1,13 +1,23 @@
 import ApplicationAdapter from './application';
 
 export default ApplicationAdapter.extend({
+
   send(id, force) {
-    var url = this.urlForDeliveryAction(id, 'send');
+    let url = this.urlForDeliveryAction(id, 'send');
     if (force) {
       url += '?force=' + force;
     }
     return this.ajax(url, 'POST');
   },
+
+  preview(details) {
+    const modelName = 'delivery-preview';
+    const url = `${this.buildURL(modelName)}`;
+    let payload = {};
+    payload[modelName] = details;
+    return this.ajax(url, 'POST', {data: payload}).then(response => { return response[modelName]; });
+  },
+
   urlForDeliveryAction(id, action) {
     return `${this.buildURL('delivery', id)}${action}/`;
   }

--- a/app/components/loading-indicator.js
+++ b/app/components/loading-indicator.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: 'span',
+  classNames: ['loading-indicator'],
+});

--- a/app/controllers/deliveries/new/confirm.js
+++ b/app/controllers/deliveries/new/confirm.js
@@ -8,6 +8,7 @@ export default Ember.Controller.extend({
   emailMessage: null,
   disableNext: false,
   errors: null,
+  errorMessages: Ember.computed.mapBy('errors', 'detail'),
   application: Ember.inject.controller(),
   currentDukeDsUser: Ember.computed.alias('application.currentDukeDsUser'),
   fromUser: Ember.computed.alias('currentDukeDsUser'),

--- a/app/controllers/deliveries/new/confirm.js
+++ b/app/controllers/deliveries/new/confirm.js
@@ -6,6 +6,7 @@ export default Ember.Controller.extend({
   toUserId: null,
   userMessage: null,
   emailMessage: null,
+  disableNext: false,
   errors: null,
   application: Ember.inject.controller(),
   currentDukeDsUser: Ember.computed.alias('application.currentDukeDsUser'),
@@ -53,6 +54,10 @@ export default Ember.Controller.extend({
       }});
     },
     saveAndSend() {
+      this.setProperties({
+        disableNext: true,
+        errors: null,
+      });
       // We have a lot of promises to resolve here.
       const store = this.get('store');
       const project = this.get('store').findRecord('duke-ds-project', this.get('projectId'));

--- a/app/controllers/deliveries/new/confirm.js
+++ b/app/controllers/deliveries/new/confirm.js
@@ -77,7 +77,14 @@ export default Ember.Controller.extend({
         savedDelivery => { return savedDelivery.send(); },
           errorResponse => { this.setProperties({ errors: errorResponse.errors, disableNext: false });
       }).then(sentDelivery => {
-        this.transitionToRoute('deliveries.show', sentDelivery.get('transfer'));
+        const projectName = sentDelivery.get('project.name');
+        const deliveryMessage = `Sent delivery notification for project ${projectName}.`;
+        const transfer = sentDelivery.get('transfer');
+        this.transitionToRoute('deliveries.show', transfer, {
+          queryParams: {
+            infoMessage: deliveryMessage
+          }
+        });
       });
     }
   }

--- a/app/controllers/deliveries/new/confirm.js
+++ b/app/controllers/deliveries/new/confirm.js
@@ -13,7 +13,9 @@ export default Ember.Controller.extend({
 
   valuesPopulated: Ember.on('init', Ember.observer('fromUser', 'projectId', 'toUserId', 'userMessage', function() {
     // Don't generate preview until all values are set.
-    // This is ugly
+    // This is ugly because it has to deal with multiple variants of properties that aren't all set at the same time:
+    // query parameters that are set by the router and a current user that is set by the application controller
+    // And on top of that, the saveAndSend method resolves promises for these.
     const values = [this.get('fromUser'), this.get('projectId'), this.get('toUserId'), this.get('userMessage')];
     if(values.compact().get('length') < 4) {
       return;

--- a/app/controllers/deliveries/new/confirm.js
+++ b/app/controllers/deliveries/new/confirm.js
@@ -1,0 +1,62 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  queryParams: ['projectId', 'toUserId', 'userMessage'],
+  projectId: null,
+  toUserId: null,
+  userMessage: null,
+  emailMessage: null,
+  errors: null,
+  application: Ember.inject.controller(),
+  currentDukeDsUser: Ember.computed.alias('application.currentDukeDsUser'),
+  fromUser: Ember.computed.alias('currentDukeDsUser'),
+
+  currentDukeDsUserChanged: Ember.on('init', Ember.observer('fromUser', function() {
+    if(!Ember.isEmpty(this.get('fromUser'))) {
+      this.generatePreview();
+    }
+  })
+  ),
+
+  generatePreview() {
+    // make a new delivery so we can call .preview() on it
+    const store = this.get('store');
+    const delivery = store.createRecord('delivery');
+
+    const details = {
+      project_id: this.get('projectId'),
+      from_user_id: this.get('fromUser.id'),
+      to_user_id: this.get('toUserId'),
+      user_message: this.get('userMessage') || '', // Must be present
+      transfer_id: '', // Must be present
+    };
+
+    delivery.preview(details).then(preview => {
+      this.set('emailMessage', preview.delivery_email_text);
+    });
+  },
+
+  actions: {
+    saveAndSend() {
+      return;
+      const delivery = this.get('store').createRecord('delivery', {
+        project: this.get('project'),
+        fromUser: this.get('fromUser'),
+        toUser: this.get('toUser'),
+        userMessage: this.get('userMessage')
+      });
+      return delivery.save().then(
+        savedDelivery => {
+          return savedDelivery.send();
+        },
+        errorResponse => {
+          this.setProperties({
+            errors: errorResponse.errors,
+            disableNext: false
+          });
+        }).then(sentDelivery => {
+        this.transitionToRoute('deliveries.show', sentDelivery.get('transfer'));
+      });
+    }
+  }
+});

--- a/app/controllers/deliveries/new/enter-user-message.js
+++ b/app/controllers/deliveries/new/enter-user-message.js
@@ -27,29 +27,17 @@ export default Ember.Controller.extend({
       const projectId = this.get('projectId');
       this.transitionToRoute('deliveries.new.select-recipient', { queryParams: { projectId: projectId }});
     },
-    saveAndSend() {
+    next() {
       this.setProperties({
         disableNext: true,
         errorMessage: null
       });
-      const delivery = this.get('store').createRecord('delivery', {
-        project: this.get('project'),
-        fromUser: this.get('fromUser'),
-        toUser: this.get('toUser'),
+      const params = {
+        projectId: this.get('projectId'),
+        toUserId: this.get('toUserId'),
         userMessage: this.get('userMessage')
-      });
-      return delivery.save().then(
-        savedDelivery => {
-          return savedDelivery.send();
-        },
-        errorResponse => {
-          this.setProperties({
-            errors: errorResponse.errors,
-            disableNext: false
-          });
-        }).then(sentDelivery => {
-        this.transitionToRoute('deliveries.show', sentDelivery.get('transfer'));
-      });
-    }
+      };
+      this.transitionToRoute('deliveries.new.confirm', { queryParams: params});
+    },
   },
 });

--- a/app/controllers/deliveries/new/enter-user-message.js
+++ b/app/controllers/deliveries/new/enter-user-message.js
@@ -21,17 +21,13 @@ export default Ember.Controller.extend({
   }),
   errors: null,
   errorMessages: Ember.computed.mapBy('errors', 'detail'),
-  disableNext: false,
   actions: {
     back() {
       const projectId = this.get('projectId');
       this.transitionToRoute('deliveries.new.select-recipient', { queryParams: { projectId: projectId }});
     },
     next() {
-      this.setProperties({
-        disableNext: true,
-        errorMessage: null
-      });
+      this.set('errors', null);
       const params = {
         projectId: this.get('projectId'),
         toUserId: this.get('toUserId'),

--- a/app/controllers/deliveries/new/enter-user-message.js
+++ b/app/controllers/deliveries/new/enter-user-message.js
@@ -37,7 +37,7 @@ export default Ember.Controller.extend({
         toUserId: this.get('toUserId'),
         userMessage: this.get('userMessage')
       };
-      this.transitionToRoute('deliveries.new.confirm', { queryParams: params});
+      this.transitionToRoute('deliveries.new.confirm', { queryParams: params });
     },
   },
 });

--- a/app/controllers/deliveries/show/resend-confirm.js
+++ b/app/controllers/deliveries/show/resend-confirm.js
@@ -1,0 +1,53 @@
+import Ember from 'ember';
+
+import CanResendController from './can-resend-controller';
+
+export default CanResendController.extend({
+  errors: null,
+  init() {
+    this._super(...arguments);
+    this.set('errors', []);
+  },
+  errorMessages: Ember.computed.mapBy('errors', 'detail'),
+
+  generatePreview() {
+    this.get('model.delivery').then((delivery) => {
+      return delivery.preview();
+    }).then(preview => {
+      this.set('emailMessage', preview.delivery_email_text);
+    });
+  },
+  actions: {
+    back() {
+      this.transitionToRoute('deliveries.show.resend', this.get('model'));
+    },
+    resend() {
+      const thisController = this;
+      function consumeError(error) {
+        thisController.set('errors', error.errors);
+      }
+      const transfer = this.get('model');
+      const projectName = transfer.get('project.name');
+      const deliveryMessage = 'Email message resent for delivery of project ' + projectName + '.';
+      // save user message changes
+      transfer.get('delivery').then(function (delivery) {
+        if (delivery) {
+          delivery.save().then(function (delivery) {
+            // resend the delivery email
+            delivery.send(true).then(function () {
+              thisController.transitionToRoute('deliveries.show', transfer, {
+                queryParams: {
+                  infoMessage: deliveryMessage
+                }
+              });
+            }, consumeError);
+          }, consumeError);
+        } else {
+          consumeError({
+            errors: [{detail:'Delivery not found.'}]
+          });
+        }
+      });
+    }
+  }
+});

--- a/app/controllers/deliveries/show/resend.js
+++ b/app/controllers/deliveries/show/resend.js
@@ -4,7 +4,6 @@ import CanResendController from './can-resend-controller';
 export default CanResendController.extend({
   errors: [],
   errorMessages: Ember.computed.mapBy('errors', 'detail'),
-  emailMessage: null,
   actions: {
     resend() {
       const thisController = this;
@@ -32,16 +31,6 @@ export default CanResendController.extend({
             errors: [{detail:'Delivery not found.'}]
           });
         }
-      });
-    },
-    preview() {
-      const delivery = this.get('model.delivery');
-      delivery.then(delivery => {
-        Ember.Logger.log(`delivery ${delivery}`);
-        return delivery.preview();
-      }).then(preview => {
-        Ember.Logger.log(`preview ${JSON.stringify(preview)}`);
-        this.set('emailMessage', preview.delivery_email_text);
       });
     }
   }

--- a/app/controllers/deliveries/show/resend.js
+++ b/app/controllers/deliveries/show/resend.js
@@ -4,6 +4,7 @@ import CanResendController from './can-resend-controller';
 export default CanResendController.extend({
   errors: [],
   errorMessages: Ember.computed.mapBy('errors', 'detail'),
+  emailMessage: null,
   actions: {
     resend() {
       const thisController = this;
@@ -31,6 +32,16 @@ export default CanResendController.extend({
             errors: [{detail:'Delivery not found.'}]
           });
         }
+      });
+    },
+    preview() {
+      const delivery = this.get('model.delivery');
+      delivery.then(delivery => {
+        Ember.Logger.log(`delivery ${delivery}`);
+        return delivery.preview();
+      }).then(preview => {
+        Ember.Logger.log(`preview ${JSON.stringify(preview)}`);
+        this.set('emailMessage', preview.delivery_email_text);
       });
     }
   }

--- a/app/controllers/deliveries/show/resend.js
+++ b/app/controllers/deliveries/show/resend.js
@@ -1,37 +1,12 @@
-import Ember from 'ember';
 import CanResendController from './can-resend-controller';
 
 export default CanResendController.extend({
-  errors: [],
-  errorMessages: Ember.computed.mapBy('errors', 'detail'),
   actions: {
+    back() {
+      this.transitionToRoute('deliveries.show', this.get('model'));
+    },
     resend() {
-      const thisController = this;
-      function consumeError(error) {
-        thisController.set('errors', error.errors);
-      }
-      const transfer = this.get('model');
-      const projectName = transfer.get('project.name');
-      const deliveryMessage = 'Email message resent for delivery of project ' + projectName + '.';
-      // save user message changes
-      transfer.get('delivery').then(function (delivery) {
-        if (delivery) {
-          delivery.save().then(function (delivery) {
-            // resend the delivery email
-            delivery.send(true).then(function () {
-              thisController.transitionToRoute('deliveries.show', transfer, {
-                queryParams: {
-                  infoMessage: deliveryMessage
-                }
-              });
-            }, consumeError);
-          }, consumeError);
-        } else {
-          consumeError({
-            errors: [{detail:'Delivery not found.'}]
-          });
-        }
-      });
+      this.transitionToRoute('deliveries.show.resend-confirm', this.get('model'));
     }
   }
 });

--- a/app/models/delivery.js
+++ b/app/models/delivery.js
@@ -20,6 +20,17 @@ export default DS.Model.extend({
     let adapter = this.store.adapterFor(this.constructor.modelName);
     return adapter.send(this.get('id'), force).then(this.updateAfterAction.bind(this));
   },
+  preview() {
+    let adapter = this.store.adapterFor(this.constructor.modelName);
+    let details = {
+      from_user_id: this.get('fromUser.id'),
+      to_user_id: this.get('toUser.id'),
+      project_id: this.get('transfer.project.id'),
+      transfer_id: this.get('transfer.id'),
+      user_message: this.get('userMessage')
+    };
+    return adapter.preview(details);
+  },
   updateAfterAction(data) {
     // The action methods respond with an updated delivery, so we must update the local store
     // with that payload. Remember, pushPayload doesn't return.

--- a/app/models/delivery.js
+++ b/app/models/delivery.js
@@ -20,7 +20,7 @@ export default DS.Model.extend({
     let adapter = this.store.adapterFor(this.constructor.modelName);
     return adapter.send(this.get('id'), force).then(this.updateAfterAction.bind(this));
   },
-  preview() {
+  preview(props) {
     let adapter = this.store.adapterFor(this.constructor.modelName);
     let details = {
       from_user_id: this.get('fromUser.id'),
@@ -29,6 +29,10 @@ export default DS.Model.extend({
       transfer_id: this.get('transfer.id'),
       user_message: this.get('userMessage')
     };
+    for(let prop in props) {
+      details[prop] = props[prop];
+    }
+
     return adapter.preview(details);
   },
   updateAfterAction(data) {

--- a/app/models/delivery.js
+++ b/app/models/delivery.js
@@ -29,10 +29,7 @@ export default DS.Model.extend({
       transfer_id: this.get('transfer.id'),
       user_message: this.get('userMessage')
     };
-    for(let prop in props) {
-      details[prop] = props[prop];
-    }
-
+    Ember.assign(details, props);
     return adapter.preview(details);
   },
   updateAfterAction(data) {

--- a/app/router.js
+++ b/app/router.js
@@ -16,6 +16,7 @@ Router.map(function() {
       this.route('select-project');
       this.route('select-recipient');
       this.route('enter-user-message');
+      this.route('confirm');
     });
   });
   this.route('get-token');

--- a/app/router.js
+++ b/app/router.js
@@ -11,6 +11,7 @@ Router.map(function() {
   this.route('deliveries', function() {
     this.route('show', { path: '/:transfer_id'}, function () {
       this.route('resend', {});
+      this.route('resend-confirm');
     });
     this.route('new', function() {
       this.route('select-project');

--- a/app/routes/deliveries/new/confirm.js
+++ b/app/routes/deliveries/new/confirm.js
@@ -4,6 +4,7 @@ export default Ember.Route.extend({
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.set('errors', null);
+      controller.set('disableNext', false);
     }
   }
 });

--- a/app/routes/deliveries/new/confirm.js
+++ b/app/routes/deliveries/new/confirm.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.set('errors', null);
+    }
+  }
+});

--- a/app/routes/deliveries/show/resend-confirm.js
+++ b/app/routes/deliveries/show/resend-confirm.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  setupController(controller, model) {
+    this._super(controller, model);
+    controller.generatePreview();
+  }
+});

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -5,3 +5,20 @@
 .select-row-checkbox-column {
   width: 2em;
 }
+
+/* spinning icons */
+
+.glyphicon.spinning {
+  animation: spin 1s infinite linear;
+  -webkit-animation: spin2 1s infinite linear;
+}
+
+@keyframes spin {
+  from { transform: scale(1) rotate(0deg); }
+  to { transform: scale(1) rotate(360deg); }
+}
+
+@-webkit-keyframes spin2 {
+  from { -webkit-transform: rotate(0deg); }
+  to { -webkit-transform: rotate(360deg); }
+}

--- a/app/templates/components/loading-indicator.hbs
+++ b/app/templates/components/loading-indicator.hbs
@@ -1,0 +1,2 @@
+<span class="glyphicon glyphicon-refresh spinning" aria-hidden="true"></span>
+{{yield}}

--- a/app/templates/deliveries/new/confirm.hbs
+++ b/app/templates/deliveries/new/confirm.hbs
@@ -14,6 +14,8 @@
   <div class="well well-sm">{{#loading-indicator}}Generating Preview{{/loading-indicator}}</div>
 {{/if}}
 
+{{error-message-alert errorMessages}}
+
 {{#bs-button type="default" onClick=(action 'back') class="back-button"}}Back{{/bs-button}}
 {{#bs-button type="primary" disabled=disableNext onClick=(action 'saveAndSend') class="pull-right next-button"}}Send Delivery{{/bs-button}}
 

--- a/app/templates/deliveries/new/confirm.hbs
+++ b/app/templates/deliveries/new/confirm.hbs
@@ -1,0 +1,3 @@
+{{#if emailMessage }}
+  {{delivery-email emailMessage}}
+{{/if}}

--- a/app/templates/deliveries/new/confirm.hbs
+++ b/app/templates/deliveries/new/confirm.hbs
@@ -1,3 +1,19 @@
-{{#if emailMessage }}
+{{delivery-breadcrumbs selectedRouteName="deliveries.confirm"}}
+<h1>New Delivery</h1>
+<h4>
+  Please confirm the delivery of <b>{{project.name}}</b> below.
+</h4>
+<p class="body">
+  The selected user will receive the following email to accept or decline the delivery.
+  Upon acceptance, the recipient will be the owner of the data set, and you will retain read-only access.
+</p>
+
+{{#if emailMessage}}
   {{delivery-email emailMessage}}
+{{else}}
+  <div class="well well-sm">{{#loading-indicator}}Generating Preview{{/loading-indicator}}</div>
 {{/if}}
+
+{{#bs-button type="default" onClick=(action 'back') class="back-button"}}Back{{/bs-button}}
+{{#bs-button type="primary" disabled=disableNext onClick=(action 'saveAndSend') class="pull-right next-button"}}Send Delivery{{/bs-button}}
+

--- a/app/templates/deliveries/new/confirm.hbs
+++ b/app/templates/deliveries/new/confirm.hbs
@@ -1,7 +1,7 @@
 {{delivery-breadcrumbs selectedRouteName="deliveries.confirm"}}
 <h1>New Delivery</h1>
 <h4>
-  Please confirm the delivery of <b>{{project.name}}</b> below.
+  Please confirm the delivery below.
 </h4>
 <p class="body">
   The selected user will receive the following email to accept or decline the delivery.

--- a/app/templates/deliveries/new/enter-user-message.hbs
+++ b/app/templates/deliveries/new/enter-user-message.hbs
@@ -33,7 +33,7 @@
 {{error-message-alert errorMessages}}
 
 {{#bs-button type="default" onClick=(action 'back') class="back-button"}}Back{{/bs-button}}
-{{#bs-button type="primary" disabled=disableNext onClick=(action 'next') class="pull-right next-button"}}
+{{#bs-button type="primary" onClick=(action 'next') class="pull-right next-button"}}
   Preview Delivery
 {{/bs-button}}
 

--- a/app/templates/deliveries/new/enter-user-message.hbs
+++ b/app/templates/deliveries/new/enter-user-message.hbs
@@ -33,8 +33,8 @@
 {{error-message-alert errorMessages}}
 
 {{#bs-button type="default" onClick=(action 'back') class="back-button"}}Back{{/bs-button}}
-{{#bs-button type="primary" disabled=disableNext onClick=(action 'saveAndSend') class="pull-right next-button"}}
-  Send Delivery
+{{#bs-button type="primary" disabled=disableNext onClick=(action 'next') class="pull-right next-button"}}
+  Preview Delivery
 {{/bs-button}}
 
 {{outlet}}

--- a/app/templates/deliveries/show/index.hbs
+++ b/app/templates/deliveries/show/index.hbs
@@ -1,4 +1,11 @@
 {{delivery-breadcrumbs selectedRouteName="deliveries.show" transfer=model}}
+
+{{#if infoMessage}}
+  {{#bs-alert type="success"}}
+    {{infoMessage}}
+  {{/bs-alert}}
+{{/if}}
+
 <div class="panel panel-default">
   <div class="panel-heading">
     <h3 class="panel-title">Project: {{model.project.name}} </h3>
@@ -7,11 +14,6 @@
     {{delivery-detail model}}
   </div>
 </div>
-{{#if infoMessage}}
-  {{#bs-alert type="success"}}
-    {{infoMessage}}
-  {{/bs-alert}}
-{{/if}}
 
 {{#if canResend}}
   {{#link-to "deliveries.show.resend" model class="btn btn-primary pull-right"}}Resend{{/link-to}}

--- a/app/templates/deliveries/show/index.hbs
+++ b/app/templates/deliveries/show/index.hbs
@@ -6,15 +6,13 @@
   <div class="panel-body">
     {{delivery-detail model}}
   </div>
-  {{#if canResend}}
-    <div class="panel-footer">
-      {{#link-to "deliveries.show.resend" model class="btn btn-primary"}}Resend{{/link-to}}
-    </div>
-  {{/if}}
 </div>
 {{#if infoMessage}}
   {{#bs-alert type="success"}}
     {{infoMessage}}
   {{/bs-alert}}
 {{/if}}
-{{outlet}}
+
+{{#if canResend}}
+  {{#link-to "deliveries.show.resend" model class="btn btn-primary pull-right"}}Resend{{/link-to}}
+{{/if}}

--- a/app/templates/deliveries/show/resend-confirm.hbs
+++ b/app/templates/deliveries/show/resend-confirm.hbs
@@ -1,0 +1,18 @@
+{{delivery-breadcrumbs selectedRouteName="deliveries.show.resend" transfer=model}}
+<h3>Re-send Delivery Email</h3>
+<p class="body">
+  The email below will be sent when you click <strong>Resend Delivery</strong>. If you do not wish to send this email,
+  click <strong>Back</strong>
+</p>
+
+{{#if emailMessage}}
+  {{delivery-email emailMessage}}
+{{else}}
+  <div class="well well-sm">{{#loading-indicator}}Generating Preview{{/loading-indicator}}</div>
+{{/if}}
+
+{{error-message-alert errorMessages}}
+
+{{#bs-button type="default" onClick=(action 'back') class="back-button"}}Back{{/bs-button}}
+{{#bs-button type="primary" disabled=disableNext onClick=(action 'resend') class="pull-right next-button"}}Resend Delivery{{/bs-button}}
+

--- a/app/templates/deliveries/show/resend.hbs
+++ b/app/templates/deliveries/show/resend.hbs
@@ -22,16 +22,9 @@
   {{#if canResend}}
     <div class="panel-footer">
       <button class="btn btn-primary" onclick={{action 'resend'}}>Send Email</button>
-      <button class="btn btn-danger" onclick={{action 'preview'}}>Preview Email</button>
     </div>
   {{/if}}
 </div>
-
-{{#if emailMessage}}
-<div>
-  <pre>{{ emailMessage }}</pre>
-</div>
-{{/if}}
 
 {{error-message-alert errorMessages}}
 

--- a/app/templates/deliveries/show/resend.hbs
+++ b/app/templates/deliveries/show/resend.hbs
@@ -19,14 +19,11 @@
       {{/detail-label-value}}
     {{/delivery-detail}}
   </div>
-  {{#if canResend}}
-    <div class="panel-footer">
-      <button class="btn btn-primary" onclick={{action 'resend'}}>Send Email</button>
-    </div>
-  {{/if}}
 </div>
 
 {{error-message-alert errorMessages}}
 
-{{outlet}}
-
+{{#bs-button type="default" onClick=(action 'back') class="back-button"}}Back{{/bs-button}}
+{{#if canResend}}
+  {{#bs-button type="primary" disabled=disableNext onClick=(action 'resend') class="pull-right next-button"}}Preview Email{{/bs-button}}
+{{/if}}

--- a/app/templates/deliveries/show/resend.hbs
+++ b/app/templates/deliveries/show/resend.hbs
@@ -22,9 +22,16 @@
   {{#if canResend}}
     <div class="panel-footer">
       <button class="btn btn-primary" onclick={{action 'resend'}}>Send Email</button>
+      <button class="btn btn-danger" onclick={{action 'preview'}}>Preview Email</button>
     </div>
   {{/if}}
 </div>
+
+{{#if emailMessage}}
+<div>
+  <pre>{{ emailMessage }}</pre>
+</div>
+{{/if}}
 
 {{error-message-alert errorMessages}}
 

--- a/tests/integration/components/loading-indicator-test.js
+++ b/tests/integration/components/loading-indicator-test.js
@@ -1,0 +1,11 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('loading-indicator', 'Integration | Component | loading indicator', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  this.render(hbs`{{#loading-indicator}}Loading...{{/loading-indicator}}`);
+  assert.equal(this.$().text().trim(), 'Loading...');
+});

--- a/tests/unit/adapters/delivery-test.js
+++ b/tests/unit/adapters/delivery-test.js
@@ -1,4 +1,5 @@
 import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
 
 moduleFor('adapter:delivery', 'Unit | Adapter | delivery', {
   // Specify the other units that are required for this test.
@@ -23,4 +24,26 @@ test('it POSTS the send action with force', function(assert) {
     assert.equal(method, 'POST');
   });
   adapter.send(2, true);
+});
+
+test('Calling preview POSTs to the delivery-previews endpoint', function(assert) {
+  let adapter = this.subject();
+  adapter.set('ajax', (url, method) => {
+    assert.equal(url, 'http://testhost/delivery-previews/');
+    assert.equal(method, 'POST');
+    return Ember.RSVP.resolve({});
+  });
+  adapter.preview();
+});
+
+test('Calling preview(details) wraps the details in a delivery-preview object', function(assert) {
+  let adapter = this.subject();
+  const payload = {some_key: 'some_value'};
+  adapter.set('ajax', (url, method, options) => {
+    assert.equal(url, 'http://testhost/delivery-previews/');
+    assert.equal(method, 'POST');
+    assert.deepEqual(options.data, {'delivery-preview': payload });
+    return Ember.RSVP.resolve({});
+  });
+  adapter.preview(payload);
 });

--- a/tests/unit/controllers/deliveries/new/confirm-test.js
+++ b/tests/unit/controllers/deliveries/new/confirm-test.js
@@ -1,12 +1,103 @@
 import { moduleFor, test } from 'ember-qunit';
+import Ember from "ember";
 
 moduleFor('controller:deliveries/new/confirm', 'Unit | Controller | deliveries/new/confirm', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['controller:application', 'service:duke-ds-user', 'service:session']
 });
 
 // Replace this with your real tests.
 test('it exists', function(assert) {
   let controller = this.subject();
   assert.ok(controller);
+});
+
+test('it handles saveAndSend action', function(assert) {
+  assert.expect(7);
+  const project = Ember.Object.create({ id: '123' });
+  const fromUser = Ember.Object.create({ id: '222' });
+  const toUser = Ember.Object.create({ id: '456' });
+  const controller = this.subject({
+    generatePreview() {
+      // Block other calls to createRecord
+    },
+    projectId: '123',
+    toUserId: '456',
+    userMessage: 'hey bob',
+    currentDukeDsUser: fromUser,
+    store: {
+      findRecord(modelName, id) {
+        return Ember.RSVP.resolve(Ember.Object.create({id: id}));
+      },
+      createRecord(modelName, payload) {
+        assert.equal(modelName, 'delivery');
+        assert.deepEqual(payload.project, project);
+        assert.deepEqual(payload.fromUser, fromUser);
+        assert.deepEqual(payload.toUser, toUser);
+        assert.equal(payload.userMessage, 'hey bob');
+        const mockDelivery = {
+          get(name) {
+            if (name === 'transfer') {
+              return 'sometransferid';
+            }
+            return null;
+          }
+        };
+        mockDelivery.save = function () {
+          return Ember.RSVP.resolve(mockDelivery);
+        };
+        mockDelivery.send = function () {
+          return Ember.RSVP.resolve(mockDelivery);
+        };
+        return mockDelivery;
+      }
+    },
+    transitionToRoute(routeName, data) {
+      assert.equal(routeName, 'deliveries.show', 'next action should transition to show new delivery');
+      assert.equal(data, 'sometransferid', 'next action should pass project_id');
+    }
+  });
+  Ember.run(() => {
+    controller.send('saveAndSend');
+  });
+});
+
+test('it handles back action', function(assert) {
+  assert.ok(false, 'Not yet implemented');
+});
+
+test('it generates a preview when all required properties set', function(assert) {
+  const projectId = '123';
+  const fromUser = Ember.Object.create({id: '222'});
+  const toUserId = '456';
+  const userMessage = 'thanks';
+  const mockDelivery = Ember.Object.create({
+    preview(details) {
+      assert.deepEqual(details, {
+        project_id: projectId,
+        from_user_id: fromUser.get('id'),
+        to_user_id: toUserId,
+        user_message: userMessage,
+        transfer_id: '',
+      });
+      return Ember.RSVP.resolve({delivery_email_text: `Subject: ${details.user_message}`});
+    }
+  });
+  const controller = this.subject({
+    fromUser: fromUser,
+    store: {
+      createRecord(modelName) {
+        assert.equal(modelName, 'delivery');
+        return mockDelivery;
+      }
+    }
+  });
+  Ember.run(() => {
+    assert.notOk(controller.get('emailMessage'));
+    controller.set('projectId', projectId);
+    assert.notOk(controller.get('emailMessage'));
+    controller.set('toUserId', toUserId);
+    assert.notOk(controller.get('emailMessage'));
+    controller.set('userMessage', userMessage);
+  });
+  assert.equal(controller.get('emailMessage'), 'Subject: thanks');
 });

--- a/tests/unit/controllers/deliveries/new/confirm-test.js
+++ b/tests/unit/controllers/deliveries/new/confirm-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:deliveries/new/confirm', 'Unit | Controller | deliveries/new/confirm', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/tests/unit/controllers/deliveries/new/confirm-test.js
+++ b/tests/unit/controllers/deliveries/new/confirm-test.js
@@ -155,7 +155,7 @@ test('it handles errors from delivery.save and does not try to send', function(a
       return Ember.RSVP.reject(errorResponse);
     },
     send() {
-      assert.fail();
+      assert.ok(false, 'send should not be called');
     }
   });
   const controller = this.subject({
@@ -201,7 +201,7 @@ test('it handles errors from delivery.send after save, and does not redirect', f
       createRecord() { return mockDelivery; }
     },
     transitionToRoute() {
-      assert.fail();
+      assert.ok(false, 'transitionToRoute should not be called');
     }
   });
   Ember.run(() => {

--- a/tests/unit/controllers/deliveries/new/confirm-test.js
+++ b/tests/unit/controllers/deliveries/new/confirm-test.js
@@ -62,7 +62,17 @@ test('it handles saveAndSend action', function(assert) {
 });
 
 test('it handles back action', function(assert) {
-  assert.ok(false, 'Not yet implemented');
+  assert.expect(3);
+  const controller = this.subject({
+    projectId: '123',
+    toUserId: '456',
+    transitionToRoute(routeName, data) {
+      assert.equal(routeName, 'deliveries.new.enter-user-message');
+      assert.equal(data.queryParams.projectId, '123');
+      assert.equal(data.queryParams.toUserId, '456');
+    }
+  });
+  controller.send('back');
 });
 
 test('it generates a preview when all required properties set', function(assert) {

--- a/tests/unit/controllers/deliveries/new/confirm-test.js
+++ b/tests/unit/controllers/deliveries/new/confirm-test.js
@@ -11,7 +11,7 @@ test('it exists', function(assert) {
 });
 
 test('it handles saveAndSend action', function(assert) {
-  assert.expect(7);
+  assert.expect(8);
   const project = Ember.Object.create({ id: '123' });
   const fromUser = Ember.Object.create({ id: '222' });
   const toUser = Ember.Object.create({ id: '456' });
@@ -37,6 +37,8 @@ test('it handles saveAndSend action', function(assert) {
           get(name) {
             if (name === 'transfer') {
               return 'sometransferid';
+            } else if(name === 'project.name') {
+              return 'someprojectname';
             }
             return null;
           }
@@ -50,9 +52,10 @@ test('it handles saveAndSend action', function(assert) {
         return mockDelivery;
       }
     },
-    transitionToRoute(routeName, data) {
+    transitionToRoute(routeName, data, params) {
       assert.equal(routeName, 'deliveries.show', 'next action should transition to show new delivery');
       assert.equal(data, 'sometransferid', 'next action should pass project_id');
+      assert.equal(params.queryParams.infoMessage, 'Sent delivery notification for project someprojectname.');
     }
   });
   Ember.run(() => {

--- a/tests/unit/controllers/deliveries/new/enter-user-message-test.js
+++ b/tests/unit/controllers/deliveries/new/enter-user-message-test.js
@@ -2,8 +2,6 @@ import { moduleFor, test } from 'ember-qunit';
 import Ember from "ember";
 
 moduleFor('controller:deliveries/new/enter-user-message', 'Unit | Controller | deliveries/new/enter user message', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
   needs: ['controller:application', 'service:duke-ds-user', 'service:session']
 });
 
@@ -59,47 +57,18 @@ test('it looks up toUser based on query param', function(assert) {
   controller.get('toUser').then(toUser => assert.equal(toUser, 'someuser'));
 });
 
-
-test('it handles saveAndSend action', function(assert) {
-  assert.expect(7);
-  const project = Ember.Object.create({ id: '123' });
-  const fromUser = Ember.Object.create({ id: '222' });
-  const toUser = Ember.Object.create({ id: '456' });
-  const controller = this.subject({
-    project: project,
-    currentDukeDsUser: fromUser,
-    toUser: toUser,
-    userMessage: 'hey bob',
-    store: {
-      createRecord(modelName, payload) {
-        assert.equal(modelName, 'delivery');
-        assert.equal(payload.project, project);
-        assert.equal(payload.fromUser, fromUser);
-        assert.equal(payload.toUser, toUser);
-        assert.equal(payload.userMessage, 'hey bob');
-        const mockDelivery = {
-          get(name) {
-            if (name === 'transfer') {
-              return 'sometransferid';
-            }
-            return null;
-          }
-        };
-        mockDelivery.save = function () {
-          return Ember.RSVP.resolve(mockDelivery);
-        };
-        mockDelivery.send = function () {
-          return Ember.RSVP.resolve(mockDelivery);
-        };
-        return mockDelivery;
-      }
-    },
+test('it handles next action', function(assert) {
+  assert.expect(4);
+  let controller = this.subject({
+    projectId: '123',
+    toUserId: 'abc',
+    userMessage: 'Hello World',
     transitionToRoute(routeName, data) {
-      assert.equal(routeName, 'deliveries.show', 'next action should transition to show new delivery');
-      assert.equal(data, 'sometransferid', 'next action should pass project_id');
+      assert.equal(routeName, 'deliveries.new.confirm', 'next action should transition to confirm');
+      assert.equal(data.queryParams.projectId, '123', 'projectId in query params');
+      assert.equal(data.queryParams.toUserId, 'abc', 'toUserId in query params');
+      assert.equal(data.queryParams.userMessage, 'Hello World', 'userMessage in query params');
     }
   });
-  Ember.run(() => {
-    controller.send('saveAndSend');
-  });
+  controller.send('next');
 });

--- a/tests/unit/controllers/deliveries/show/resend-confirm-test.js
+++ b/tests/unit/controllers/deliveries/show/resend-confirm-test.js
@@ -19,7 +19,7 @@ test('it transitions to deliveries.show after resend', function(assert) {
     },
     delivery: Ember.RSVP.resolve(delivery)
   });
-
+  delivery.set('transfer', transfer);
   delivery.save = function () {
     return Ember.RSVP.resolve(delivery);
   };

--- a/tests/unit/controllers/deliveries/show/resend-confirm-test.js
+++ b/tests/unit/controllers/deliveries/show/resend-confirm-test.js
@@ -1,0 +1,122 @@
+import { moduleFor, test } from 'ember-qunit';
+import Ember from "ember";
+
+moduleFor('controller:deliveries/show/resend-confirm', 'Unit | Controller | deliveries/show/resend confirm', {
+  needs: ['controller:application']
+});
+
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});
+
+test('it transitions to deliveries.show after resend', function(assert) {
+  let done = assert.async();
+  const delivery = Ember.Object.create({});
+  const transfer = Ember.Object.create({
+    project: {
+      name: 'mouse'
+    },
+    delivery: Ember.RSVP.resolve(delivery)
+  });
+
+  delivery.save = function () {
+    return Ember.RSVP.resolve(delivery);
+  };
+
+  delivery.send = function (force) {
+    assert.equal(force, true);
+    return Ember.RSVP.resolve(delivery);
+  };
+
+  let controller = this.subject({
+    model: transfer,
+    transitionToRoute(routeName, object, options) {
+      assert.equal(routeName, 'deliveries.show');
+      assert.equal(object, transfer);
+      assert.equal(options.queryParams.infoMessage, 'Email message resent for delivery of project mouse.');
+      done();
+    }
+  });
+  controller.send('resend');
+});
+
+test('when save fails the message is added to errorMessages', function(assert) {
+  const mockError = Ember.Object.create({
+    status: 400,
+    detail: 'Error saving delivery.'
+  });
+  const delivery = Ember.Object.create({});
+  const transfer = Ember.Object.create({
+    project: {
+      name: 'mouse'
+    },
+    delivery: Ember.RSVP.resolve(delivery)
+  });
+
+  delivery.save = function () {
+    return Ember.RSVP.reject({errors: [mockError]});
+  };
+
+  let controller = this.subject({
+    model: transfer
+  });
+
+  Ember.run(() => {
+    controller.send('resend');
+  });
+  Ember.run(() => {
+    assert.deepEqual(controller.get('errorMessages'), ['Error saving delivery.']);
+  });
+});
+
+test('when save fails with 500 the message is added to errorMessages', function(assert) {
+  const mockError = Ember.Object.create({
+    status: 500,
+    detail: 'Sending service is down.'
+  });
+  const delivery = Ember.Object.create({});
+  const transfer = Ember.Object.create({
+    project: {
+      name: 'mouse'
+    },
+    delivery: Ember.RSVP.resolve(delivery)
+  });
+
+  delivery.save = function () {
+    return Ember.RSVP.resolve(delivery);
+  };
+
+  delivery.send = function () {
+    return Ember.RSVP.reject({errors: [mockError]});
+  };
+
+  let controller = this.subject({
+    model: transfer
+  });
+  Ember.run(() => {
+    controller.send('resend');
+  });
+  Ember.run(() => {
+    assert.deepEqual(controller.get('errorMessages'), ['Sending service is down.']);
+  });
+});
+
+test('when save fails due to missing delivery the message is added to errorMessages', function(assert) {
+  const transfer = Ember.Object.create({
+    project: {
+      name: 'mouse'
+    },
+    delivery: Ember.RSVP.resolve(null)
+  });
+
+  let controller = this.subject({
+    model: transfer
+  });
+  Ember.run(() => {
+    controller.send('resend');
+  });
+  Ember.run(() => {
+    assert.deepEqual(controller.get('errorMessages'), ['Delivery not found.']);
+  });
+});

--- a/tests/unit/controllers/deliveries/show/resend-test.js
+++ b/tests/unit/controllers/deliveries/show/resend-test.js
@@ -2,117 +2,23 @@ import { moduleFor, test } from 'ember-qunit';
 import Ember from 'ember';
 
 moduleFor('controller:deliveries/show/resend', 'Unit | Controller | deliveries/show/resend', {
-  // Specify the other units that are required for this test.
   needs: ['controller:application']
 });
 
-test('it transitions to deliveries.show after resend', function(assert) {
-  let done = assert.async();
-  const delivery = Ember.Object.create({});
-  const transfer = Ember.Object.create({
-    project: {
-        name: 'mouse'
-    },
-    delivery: Ember.RSVP.resolve(delivery)
-  });
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});
 
-  delivery.save = function () {
-      return Ember.RSVP.resolve(delivery);
-  };
-
-  delivery.send = function (force) {
-      assert.equal(force, true);
-      return Ember.RSVP.resolve(delivery);
-  };
-
+test('it redirects to confirmation page on resend action', function(assert) {
+  assert.expect(2);
+  const mockModel = Ember.Object.create();
   let controller = this.subject({
-    model: transfer,
-    transitionToRoute(routeName, object, options) {
-      assert.equal(routeName, 'deliveries.show');
-      assert.equal(object, transfer);
-      assert.equal(options.queryParams.infoMessage, 'Email message resent for delivery of project mouse.');
-      done();
+    model: mockModel,
+    transitionToRoute(routeName, model) {
+      assert.equal(routeName, 'deliveries.show.resend-confirm');
+      assert.equal(model, mockModel);
     }
   });
   controller.send('resend');
-});
-
-test('when save fails the message is added to errorMessages', function(assert) {
-  const mockError = Ember.Object.create({
-      status: 400,
-      detail: 'Error saving delivery.'
-  });
-  const delivery = Ember.Object.create({});
-  const transfer = Ember.Object.create({
-    project: {
-      name: 'mouse'
-    },
-    delivery: Ember.RSVP.resolve(delivery)
-  });
-
-  delivery.save = function () {
-    return Ember.RSVP.reject({errors: [mockError]});
-  };
-
-  let controller = this.subject({
-    model: transfer
-  });
-
-  Ember.run(() => {
-    controller.send('resend');
-  });
-  Ember.run(() => {
-    assert.deepEqual(controller.get('errorMessages'), ['Error saving delivery.']);
-  });
-});
-
-test('when save fails with 500 the message is added to errorMessages', function(assert) {
-  const mockError = Ember.Object.create({
-    status: 500,
-    detail: 'Sending service is down.'
-  });
-  const delivery = Ember.Object.create({});
-  const transfer = Ember.Object.create({
-    project: {
-      name: 'mouse'
-    },
-    delivery: Ember.RSVP.resolve(delivery)
-  });
-
-  delivery.save = function () {
-    return Ember.RSVP.resolve(delivery);
-  };
-
-  delivery.send = function () {
-    return Ember.RSVP.reject({errors: [mockError]});
-  };
-
-  let controller = this.subject({
-    model: transfer
-  });
-  Ember.run(() => {
-    controller.send('resend');
-  });
-  Ember.run(() => {
-    assert.deepEqual(controller.get('errorMessages'), ['Sending service is down.']);
-  });
-});
-
-test('when save fails due to missing delivery the message is added to errorMessages', function(assert) {
-  const transfer = Ember.Object.create({
-    project: {
-      name: 'mouse'
-    },
-    delivery: Ember.RSVP.resolve(null)
-  });
-
-  let controller = this.subject({
-    model: transfer
-  });
-  Ember.run(() => {
-    controller.send('resend');
-  });
-  Ember.run(() => {
-    assert.deepEqual(controller.get('errorMessages'), ['Delivery not found.']);
-  });
 });

--- a/tests/unit/models/delivery-test.js
+++ b/tests/unit/models/delivery-test.js
@@ -76,7 +76,7 @@ test('delivery.preview() calls adapter.preview() with properties from delivery',
     const model = this.subject();
     model.setProperties({
       fromUser: fromUser,
-      toUser, toUser,
+      toUser: toUser,
       transfer: transfer,
       userMessage: userMessage
     });
@@ -115,7 +115,7 @@ test('Parameters to delivery.preview() override model properties in call to adap
     const model = this.subject();
     model.setProperties({
       fromUser: fromUser,
-      toUser, toUser,
+      toUser: toUser,
       transfer: transfer,
       userMessage: originalUserMessage,
     });

--- a/tests/unit/routes/deliveries/new/confirm-test.js
+++ b/tests/unit/routes/deliveries/new/confirm-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:deliveries/new/confirm', 'Unit | Route | deliveries/new/confirm', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/tests/unit/routes/deliveries/new/confirm-test.js
+++ b/tests/unit/routes/deliveries/new/confirm-test.js
@@ -1,11 +1,28 @@
 import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
 
 moduleFor('route:deliveries/new/confirm', 'Unit | Route | deliveries/new/confirm', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
 });
 
 test('it exists', function(assert) {
   let route = this.subject();
   assert.ok(route);
+});
+
+test('it clears errors and disableNext when exiting', function(assert) {
+  const controller = Ember.Object.create({
+    errors: [1,2,3],
+    disableNext: true,
+  });
+  let route = this.subject();
+  assert.ok(controller.get('errors'));
+  assert.ok(controller.get('disableNext'));
+
+  route.resetController(controller, false);
+  assert.ok(controller.get('errors'));
+  assert.ok(controller.get('disableNext'));
+
+  route.resetController(controller, true);
+  assert.notOk(controller.get('errors'));
+  assert.notOk(controller.get('disableNext'));
 });

--- a/tests/unit/routes/deliveries/show/resend-confirm-test.js
+++ b/tests/unit/routes/deliveries/show/resend-confirm-test.js
@@ -1,0 +1,23 @@
+import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+
+moduleFor('route:deliveries/show/resend-confirm', 'Unit | Route | deliveries/show/resend confirm', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});
+
+test('it calls generatePreview on the controller', function(assert) {
+  assert.expect(1);
+  let route = this.subject();
+  let mockController = Ember.Object.create({
+    generatePreview() {
+      assert.ok(true);
+    }
+  });
+  route.setupController(mockController);
+});

--- a/tests/unit/routes/deliveries/show/resend-confirm-test.js
+++ b/tests/unit/routes/deliveries/show/resend-confirm-test.js
@@ -2,8 +2,6 @@ import { moduleFor, test } from 'ember-qunit';
 import Ember from 'ember';
 
 moduleFor('route:deliveries/show/resend-confirm', 'Unit | Route | deliveries/show/resend confirm', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
 });
 
 test('it exists', function(assert) {


### PR DESCRIPTION
- Adds preview method to delivery model and adapter, POSTing to [delivery-previews API](https://github.com/Duke-GCB/D4S2/pull/172)
- Adds confirm routes at end of creating new delivery and resending existing, that displays the preview before sending

There is some duplicated logic and presentation here begging for a refactor, which I will address in a subsequent discussion/PR. I felt there were enough changes here to go ahead though.