### PR TITLE
Update successRoute to /

### DIFF
--- a/app/controllers/get-token.js
+++ b/app/controllers/get-token.js
@@ -1,6 +1,6 @@
 import GetTokenController from 'drf-ember-frontend/controllers/get-token';
 
 export default GetTokenController.extend({
-  successRoute: '/deliveries',
+  successRoute: '/',
   failureRoute: '/login',
 });

--- a/tests/unit/controllers/get-token-test.js
+++ b/tests/unit/controllers/get-token-test.js
@@ -17,6 +17,6 @@ test('it exists', function(assert) {
     transitionToRoute() {}
   });
   assert.ok(controller);
-  assert.equal(controller.get('successRoute'), '/deliveries');
+  assert.equal(controller.get('successRoute'), '/');
   assert.equal(controller.get('failureRoute'), '/login');
 });


### PR DESCRIPTION
Upon successful login, users are now redirected to `/` instead of `/deliveries`.

Fixes #49 