### PR TITLE
Ember3 dockerfile fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ jobs:
           command: |
             npm config set spin false
             npm install
-            npm install phantomjs-prebuilt
 
       - save_cache:
           paths:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ADD package.json /src/package.json
 ADD package-lock.json /src/package-lock.json
 RUN npm install
 ADD . /src/
-
 # add CI flag so chrome --no-sandbox flag will be used
 RUN CI=true npm test
 RUN npm run build -- --environment production

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,18 @@ WORKDIR /src
 ADD package.json /src/package.json
 ADD package-lock.json /src/package-lock.json
 RUN npm install
-RUN npm install phantomjs-prebuilt
+# Install latest chrome package so we can run tests
+# Copied from https://github.com/GoogleChromeLabs/lighthousebot/blob/master/builder/Dockerfile
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-unstable --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /src/*.deb
 ADD . /src/
-RUN npm test
+
+# add CI flag so chrome --no-sandbox flag will be used
+RUN CI=true npm test
 RUN npm run build -- --environment production
 
 FROM nginx:1.13

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,11 @@
-FROM node:8 as builder
+FROM circleci/node:8.9-browsers as builder
+# The base image sets USER to circleci.
+# Reset user back to root so we have permissions for the ADDed files.
+USER root
 WORKDIR /src
 ADD package.json /src/package.json
 ADD package-lock.json /src/package-lock.json
 RUN npm install
-# Install latest chrome package so we can run tests
-# Copied from https://github.com/GoogleChromeLabs/lighthousebot/blob/master/builder/Dockerfile
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-unstable --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /src/*.deb
 ADD . /src/
 
 # add CI flag so chrome --no-sandbox flag will be used


### PR DESCRIPTION
After upgrading to ember3 we are using headless chrome instead of phantomjs for testing.
This caused an error building our Dockerfile because chrome was not installed.
Changes here switch to use the `circleci/node:8.9-browsers` for our Dockerfile builder image.
We are already using this image to run tests in CircleCI.

There is a new environment variable `CI` set to `true` when running tests in the docker image.
Without this flag chrome will fail when trying to run emberjs tests.

This change also removes no longer necessary phantomjs installation.

Fixes #58 
