### PR TITLE
Switch from {{bs-button}} to <BsButton>

### DIFF
--- a/app/templates/components/share-users-table.hbs
+++ b/app/templates/components/share-users-table.hbs
@@ -19,7 +19,7 @@
         {{ shareUser.email }}
       </td>
       <td>
-        {{#bs-button type="default" onClick=(action "removeUser" shareUser) class="back-button"}}Remove{{/bs-button}}
+        <BsButton @type="default" class="back-button" @onClick={{action "removeUser" shareUser}}>Remove</BsButton>
       </td>
     </tr>
   {{/each}}
@@ -34,9 +34,9 @@
 <tfoot>
   <tr>
     <td colspan="4" class="share-users-table-footer">
-      {{#bs-button type="primary" onClick=(action "addUser") class="share-users-table-add-user pull-right btn-sm"}}
+      <BsButton @type="primary" class="share-users-table-add-user pull-right btn-sm" @onClick={{action "addUser"}}>
         Add User
-      {{/bs-button}}
+      </BsButton>
     </td>
   </tr>
 </tfoot>

--- a/app/templates/deliveries/new/confirm.hbs
+++ b/app/templates/deliveries/new/confirm.hbs
@@ -14,4 +14,6 @@
 {{error-message-alert errorMessages}}
 
 {{#link-to backRoute (query-params projectId=projectId toUserId=toUserId userMessage=userMessage) class="btn btn-default"}}Back{{/link-to}}
-{{#bs-button type="primary" disabled=disableNext onClick=(action "saveAndSend") class="pull-right next-button"}}Send Delivery{{/bs-button}}
+<BsButton class="pull-right next-button" disabled={{disableNext}} @type="primary" @onClick={{action "saveAndSend"}}>
+  Send Delivery
+</BsButton>

--- a/app/templates/deliveries/new/select-share-user.hbs
+++ b/app/templates/deliveries/new/select-share-user.hbs
@@ -11,6 +11,6 @@
 }}
 
 {{#link-to "deliveries.new.select-share-users" class="btn btn-default"}}Cancel{{/link-to}}
-{{#bs-button onClick=(action "save") class="btn btn-primary pull-right" disabled=disableSave}}Add User{{/bs-button}}
+<BsButton class="btn btn-primary pull-right" disabled={{disableSave}} @onClick={{action "save"}}>Add User</BsButton>
 
 {{outlet}}

--- a/app/templates/deliveries/show/recall.hbs
+++ b/app/templates/deliveries/show/recall.hbs
@@ -8,8 +8,9 @@
   not longer available for delivery.
 </p>
 
-{{#bs-button type="default" onClick=(action "back") class="back-button"}}Back{{/bs-button}}
-
-{{#bs-button type="danger" disabled=disableNext onClick=(action "recallDelivery")  class="pull-right next-button"}}Recall Delivery{{/bs-button}}
+<BsButton @type="default" class="back-button" @onClick={{action "back"}}>Back</BsButton>
+<BsButton class="pull-right next-button" @type="danger" disabled={{disableNext}} @onClick={{action "recallDelivery"}}>
+  Recall Deliver
+</BsButton>
 
 {{outlet}}

--- a/app/templates/deliveries/show/resend-confirm.hbs
+++ b/app/templates/deliveries/show/resend-confirm.hbs
@@ -9,6 +9,7 @@
 
 {{error-message-alert errorMessages}}
 
-{{#bs-button type="default" onClick=(action "back") class="back-button"}}Back{{/bs-button}}
-{{#bs-button type="primary" disabled=disableNext onClick=(action "resend") class="pull-right next-button"}}Resend Delivery{{/bs-button}}
-
+<BsButton @type="default" class="back-button" @onClick={{action "back"}}>Back</BsButton>
+<BsButton class="pull-right next-button" @type="primary" disabled={{disableNext}} @onClick={{action "resend"}}>
+  Resend Delivery
+</BsButton>

--- a/app/templates/deliveries/show/resend.hbs
+++ b/app/templates/deliveries/show/resend.hbs
@@ -21,7 +21,9 @@
 
 {{error-message-alert errorMessages}}
 
-{{#bs-button type="default" onClick=(action "back") class="back-button"}}Back{{/bs-button}}
+<BsButton @type="default" class="back-button" @onClick={{action "back"}}>Remove</BsButton>
 {{#if canResend}}
-  {{#bs-button type="primary" disabled=disableNext onClick=(action "resend") class="pull-right next-button"}}Preview Email{{/bs-button}}
+  <BsButton class="pull-right next-button" @type="primary" disabled={{disableNext}} @onClick={{action "resend"}}>
+     Preview Email
+  </BsButton>
 {{/if}}

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -17,7 +17,7 @@
           {{#if errorMessage}}
             {{#bs-alert type="danger" dismissible=false}}Unable to authenticate: {{errorMessage}}{{/bs-alert}}
           {{/if}}
-          {{#bs-button type="default" onClick=(action "authenticate")}}Login{{/bs-button}}
+          <BsButton @type="default" @onClick={{action "authenticate"}}>Login</BsButton>
         {{/bs-form}}
       </div>
     </div>


### PR DESCRIPTION
Switches from `{{bs-button}}` to `<BsButton>` since `class` attribute only works for the angle bracket syntax.
Fixes #85 