### PR TITLE
Add loading page

### DIFF
--- a/app/templates/loading.hbs
+++ b/app/templates/loading.hbs
@@ -1,1 +1,3 @@
-<h4>Loading ... please wait.</h4>
+<h4>
+  {{#loading-indicator}}Loading{{/loading-indicator}}
+</h4>

--- a/app/templates/loading.hbs
+++ b/app/templates/loading.hbs
@@ -1,0 +1,1 @@
+<h4>Loading ... please wait.</h4>


### PR DESCRIPTION
Adds default loading page so users will know to wait when the website loads.
Loading is noticeably slower due to the fetching the list of deliveries from the DukeDS API.
This endpoint has gotten slower over time.